### PR TITLE
Add FromZeroes derivations to PackIt structs

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -9,9 +9,9 @@ use core::mem::size_of_val;
 #[cfg(feature = "std")]
 use std::io::Write;
 use zerocopy::byteorder::LittleEndian;
-use zerocopy::{AsBytes, FromBytes, U16, U64};
+use zerocopy::{AsBytes, FromBytes, FromZeroes, U16, U64};
 
-#[derive(Clone, Copy, Debug, FromBytes, AsBytes)]
+#[derive(Clone, Copy, Debug, FromBytes, FromZeroes, AsBytes)]
 #[repr(C, packed)]
 struct PackItFileHeaderPrelude {
     // TODO: make a repr(u16) enum out of this field with the

--- a/src/header.rs
+++ b/src/header.rs
@@ -9,13 +9,13 @@ use core::mem::size_of;
 #[cfg(feature = "std")]
 use std::io::Write;
 use zerocopy::byteorder::LittleEndian;
-use zerocopy::{AsBytes, FromBytes, U32};
+use zerocopy::{AsBytes, FromBytes, FromZeroes, U32};
 
 /// Header Magic (PKIT)
 pub const PACKIT_MAGIC: [u8; 4] = [0x50, 0x4b, 0x49, 0x54];
 
 /// A PackIt archive header
-#[derive(AsBytes, Clone, Copy, Debug, FromBytes)]
+#[derive(AsBytes, Clone, Copy, Debug, FromBytes, FromZeroes)]
 #[repr(C)]
 pub struct PackItHeader {
     magic: [u8; 4],


### PR DESCRIPTION
Resolves a build error when using Bazel Rust rules.